### PR TITLE
ci: test the publish tip and serialize releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,4 +80,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm release
+        run: |
+          if git log -1 --format='%s' | grep -qE '^chore\(release\)'; then
+            echo "tip is already a release commit — nothing to publish"
+            exit 0
+          fi
+          pnpm release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   SKIP_INSTALL_SIMPLE_GIT_HOOKS: true
 
@@ -59,6 +63,11 @@ jobs:
           version: latest
       - name: Install
         run: pnpm install --dangerously-allow-all-builds
+      - name: Sync master
+        run: |
+          git config --global user.email "${{ secrets.GIT_EMAIL }}"
+          git config --global user.name "${{ secrets.GIT_USERNAME }}"
+          git pull origin master
       - name: Test
         run: pnpm test
       - name: Report
@@ -71,8 +80,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          git config --global user.email "${{ secrets.GIT_EMAIL }}"
-          git config --global user.name "${{ secrets.GIT_USERNAME }}"
-          git pull origin master
-          pnpm release
+        run: pnpm release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,13 +61,13 @@ jobs:
         uses: pnpm/action-setup@v6
         with:
           version: latest
-      - name: Install
-        run: pnpm install --dangerously-allow-all-builds
       - name: Sync master
         run: |
           git config --global user.email "${{ secrets.GIT_EMAIL }}"
           git config --global user.name "${{ secrets.GIT_USERNAME }}"
           git pull origin master
+      - name: Install
+        run: pnpm install --dangerously-allow-all-builds
       - name: Test
         run: pnpm test
       - name: Report

--- a/test/install.js
+++ b/test/install.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const install = require('../bin/init')
-const test = require('ava')
+const test = require('ava').default
 
 test("throw an error if package.json doesn't exist", async t => {
   const error = await t.throwsAsync(install())


### PR DESCRIPTION
Same two release-safety holes fixed in [microlinkhq/microlink#6](https://github.com/microlinkhq/microlink/pull/6).

## 1. Published untested tip

The release job ran `pnpm test` on the trigger SHA (detached checkout), then `git pull origin master` advanced to tip **before** `pnpm release`. When the `contributors` job or a concurrent push moved the tip, the published commit was never tested in this run.

Fix: move `git pull` (and git identity) into a `Sync master` step **before** `Test`, so the suite runs on the exact commit being published.

## 2. Concurrent double-publish

No `concurrency` guard. Two pushes landing close together could run `pnpm release` + `pnpm publish` at the same time and race on tag pushes, leaving a half-published state (npm published, git tag not).

Fix: `concurrency: { group: release-${{ github.ref }}, cancel-in-progress: false }` — publishes serialize, and an in-flight publish is never cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZKpkLcBt4Z1t7Xronhet4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI orchestration and a test import; no runtime library or auth/data paths are modified.
> 
> **Overview**
> Hardens the **main** release workflow so CI tests the same commit that gets published and only one release runs at a time.
> 
> **Concurrency** is added with `group: release-${{ github.ref }}` and `cancel-in-progress: false`, so overlapping pushes queue instead of racing on `pnpm release` / npm publish.
> 
> **Sync master** (git identity + `git pull`) now runs **before** install and **Test**, so the suite runs on the tip that release will use—not the detached trigger SHA that could be behind master after the contributors job.
> 
> The **Release** step skips `pnpm release` when HEAD is already a `chore(release)` commit, avoiding a redundant publish when the tip moved to an automated release commit.
> 
> **test/install.js** switches to `require('ava').default` for compatibility with current Ava ESM exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bdd5743c23e167b16e0b9481ad368b2301d3965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->